### PR TITLE
Add built-in `property_exists(object, prop-name [, direct-only])`

### DIFF
--- a/src/property.cc
+++ b/src/property.cc
@@ -329,6 +329,40 @@ bf_is_clear_prop(Var arglist, Byte next, void *vdata, Objid progr)
         return make_error_pack(e);
 }
 
+static package
+bf_property_exists(Var arglist, Byte next, void *vdata, Objid progr)
+{   /* (object, prop-name [, direct-only]) */
+    Var obj = arglist.v.list[1];
+    const char *pname = arglist.v.list[2].v.str;
+    int direct = 0;
+    db_prop_handle h;
+    Var r;
+
+    if (arglist.v.list[0].v.num == 3)
+        direct = is_true(arglist.v.list[3]);
+
+    if (!obj.is_object()) {
+        free_var(arglist);
+        return make_error_pack(E_TYPE);
+    }
+    else if (!is_valid(obj)) {
+        free_var(arglist);
+        return make_error_pack(E_INVARG);
+    }
+
+    h = db_find_property(obj, pname, nullptr);
+    free_var(arglist);
+
+    if (!h.ptr)
+        r = Var::new_int(0);
+    else if (!db_is_property_built_in(h) && !db_property_allows(h, progr, PF_READ))
+        return make_error_pack(E_PERM);
+    else
+        r = Var::new_int(!direct || db_is_property_defined_on(h, obj));
+
+    return make_var_pack(r);
+}
+
 void
 register_property(void)
 {
@@ -346,4 +380,6 @@ register_property(void)
                              TYPE_ANY, TYPE_STR);
     (void) register_function("is_clear_property", 2, 2, bf_is_clear_prop,
                              TYPE_ANY, TYPE_STR);
+    (void) register_function("property_exists", 2, 3, bf_property_exists,
+                             TYPE_ANY, TYPE_STR, TYPE_INT);
 }


### PR DESCRIPTION
### Motivation
- Provide a simple builtin to check whether a property exists on an object while respecting read permissions and an optional `direct-only` flag. 

### Description
- Added `bf_property_exists` in `src/property.cc` implementing `(object, prop-name[, direct-only])` which validates arguments, finds the property handle, enforces read permission, and returns an integer 0/1 result. 
- Registered the new function in `register_property` as `property_exists` with arity 2–3 and types `TYPE_ANY, TYPE_STR, TYPE_INT`. 
- The implementation reuses existing DB helpers `db_find_property`, `db_is_property_built_in`, `db_property_allows`, and `db_is_property_defined_on` for lookup and permission checks. 

### Testing
- Project was compiled and the automated test suite was executed and completed successfully. 
- Targeted tests exercising property lookup, permission-denied cases, and the `direct-only` behavior were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08da34b2f8832e8aea2f0d78414315)