### PR TITLE
[codex] Prevent SQL pool cleanup in checkpoint children

### DIFF
--- a/src/sql.cc
+++ b/src/sql.cc
@@ -40,8 +40,7 @@
 #include <pcre.h>
 #include <mutex>   // std::once_flag, std::call_once
 
-// SET THIS TO FALSE FOR PROD!
-static bool debugging = true;  // Set to false to disable local logs in prod
+static bool debugging = false;
 #define DLOG(...) do { if (debugging) oklog(__VA_ARGS__); } while (0)
 
 /* Strip newlines for MOO strings (tabs instead). */
@@ -467,13 +466,24 @@ class PostgreSQLSessionPool: public SQLSessionPool {
 };
 #endif // POSTGRESQL_FOUND
 
-static std::unordered_map<unsigned short, std::unique_ptr<SQLSessionPool>> connection_pools;
+using SQLConnectionPools = std::unordered_map<unsigned short, std::unique_ptr<SQLSessionPool>>;
+
+static SQLConnectionPools&
+sql_connection_pools()
+{
+    /* Forked checkpointers exit through exit(), which runs C++ static
+       destructors. Keep SQL pools off the static destructor list so a
+       checkpoint child never waits on mutexes inherited from parent threads. */
+    static SQLConnectionPools *pools = new SQLConnectionPools();
+    return *pools;
+}
 
 static int
 next_identifier()
 {
     int id = -1;
     int next_id = 1;
+    auto& connection_pools = sql_connection_pools();
     while (id < 0) {
         if (!connection_pools.count(next_id)) {
             id = next_id;
@@ -486,7 +496,7 @@ next_identifier()
 
 void sql_shutdown()
 {
-    connection_pools.clear();
+    sql_connection_pools().clear();
 }
 
 // Adapter to satisfy background_thread(void (*)(Var, Var*, void*), ...)
@@ -504,6 +514,7 @@ static SQLSessionPool* create_session_pool(std::string connection_string, unsign
 #endif
 
     if (pool) {
+        auto& connection_pools = sql_connection_pools();
         pool->handle_id = handle_id;
         pool->options = options;
         connection_pools[handle_id] = std::move(pool);
@@ -518,6 +529,7 @@ static SQLSessionPool* get_or_create_session_pool(
     unsigned char options = SQL_PARSE_TYPES | SQL_PARSE_OBJECTS
 )
 {
+    auto& connection_pools = sql_connection_pools();
     for (auto& item: connection_pools) {
         if (item.second->connection_uri->full_string == connection_string) {
             return item.second.get();
@@ -534,6 +546,7 @@ query_callback(const Var arglist, Var *ret)
     std::string query = arglist.v.list[2].v.str;
 
     SQLSession* session = nullptr;
+    auto& connection_pools = sql_connection_pools();
     auto pool_it = connection_pools.find(handle_id);
     if (pool_it == connection_pools.end()) {
         *ret = str_dup_to_var("No connection handle value found by that ID.");
@@ -614,6 +627,7 @@ bf_sql_query (Var arglist, Byte next, void *vdata, Objid progr)
     }
 
     int handle_id = arglist.v.list[1].v.num;
+    auto& connection_pools = sql_connection_pools();
     auto handle = connection_pools.find(handle_id);
     if (handle == connection_pools.end()) {
         free_var(arglist);
@@ -653,6 +667,7 @@ bf_sql_connections (Var arglist, Byte next, void *vdata, Objid progr)
     }
 
     Var ret = new_map();
+    auto& connection_pools = sql_connection_pools();
     for (auto const& item: connection_pools) {
         Var key;
         key.type = TYPE_INT;
@@ -705,6 +720,7 @@ bf_sql_close_connection (Var arglist, Byte next, void *vdata, Objid progr)
     }
 
     int handle_id = arglist.v.list[1].v.num;
+    auto& connection_pools = sql_connection_pools();
     auto handle = connection_pools.find(handle_id);
     if (handle == connection_pools.end()) {
         free_var(arglist);
@@ -742,6 +758,7 @@ bf_sql_info(Var arglist, Byte next, void *vdata, Objid progr)
     }
 
     int handle_id = arglist.v.list[1].v.num;
+    auto& connection_pools = sql_connection_pools();
     auto handle = connection_pools.find(handle_id);
     if (handle == connection_pools.end()) {
         free_var(arglist);

--- a/test/tests/test_sql.rb
+++ b/test/tests/test_sql.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class TestSql < Test::Unit::TestCase
+
+  NO_HANDLE = 'No connection handle value by that ID.'
+
+  def test_that_sql_functions_require_wizperms
+    skip_unless_sql_available
+
+    run_test_as('programmer') do
+      assert_equal E_PERM, simplify(command(%Q|; return sql_connections();|))
+      assert_equal E_PERM, simplify(command(%Q|; return sql_open("nosuchdb://localhost/db");|))
+      assert_equal E_PERM, simplify(command(%Q|; return sql_query(9999, "select 1");|))
+      assert_equal E_PERM, simplify(command(%Q|; return sql_info(9999);|))
+      assert_equal E_PERM, simplify(command(%Q|; return sql_close(9999);|))
+    end
+  end
+
+  def test_that_sql_connections_is_empty_without_open_pools
+    skip_unless_sql_available
+
+    run_test_as('wizard') do
+      assert_equal({}, simplify(command(%Q|; return sql_connections();|)))
+    end
+  end
+
+  def test_that_invalid_sql_handles_return_a_plain_error_message
+    skip_unless_sql_available
+
+    run_test_as('wizard') do
+      assert_equal NO_HANDLE, simplify(command(%Q|; return sql_query(9999, "select 1");|))
+      assert_equal NO_HANDLE, simplify(command(%Q|; return sql_info(9999);|))
+      assert_equal NO_HANDLE, simplify(command(%Q|; return sql_close(9999);|))
+    end
+  end
+
+  def test_that_sql_open_rejects_invalid_uris_without_connecting
+    skip_unless_sql_available
+
+    run_test_as('wizard') do
+      assert_equal E_INVARG, simplify(command(%Q|; return sql_open("not-a-uri");|))
+      assert_equal E_INVARG, simplify(command(%Q|; return sql_open("postgresql://");|))
+      assert_equal E_INVARG, simplify(command(%Q|; return sql_open("nosuchdb://localhost/db");|))
+      assert_equal({}, simplify(command(%Q|; return sql_connections();|)))
+    end
+  end
+
+  private
+
+  def skip_unless_sql_available
+    run_test_as('wizard') do
+      omit('SQL builtins are not registered in this build') unless has_function?('sql_connections')
+    end
+  end
+
+end


### PR DESCRIPTION
## Summary

This PR keeps SQL connection pool state out of C++ static destruction so forked checkpoint children do not run SQL/pqxx cleanup paths inherited from the parent process.

## Root Cause

Forked checkpoint children leave through the normal process exit path. That can run C++ static destructors in the child. The SQL connection pool map owned `SQLSessionPool` objects statically, and those destructors call cleanup paths that lock or wait on mutexes. If a Postgres query was active when the parent forked the checkpointer, the child could inherit a locked mutex with no owning thread and remain alive indefinitely.

## Changes

- Default SQL debug logging to off.
- Replace the file-scope static SQL pool map with a heap-backed accessor so checkpoint children do not run its destructor at process exit.
- Preserve explicit parent cleanup via `sql_shutdown()`.
- Add low-friction SQL builtin tests that do not require a live Postgres server.

## Validation

- `cmake --build build --target moo -j2`
- `bundle exec ruby -r rubygems -Itests/lib tests/test_sql.rb`

The full Ruby suite was also exercised; it completed with unrelated pre-existing/environment-sensitive failures in `test_fileio.rb`, `test_map.rb`, and `test_system_builtins.rb`.